### PR TITLE
export default expirable

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -9,37 +9,6 @@ import (
 	"time"
 )
 
-type expirableValue struct {
-	value     interface{}
-	entryTime time.Time
-}
-
-func (e *expirableValue) Value() interface{} {
-	if e == nil {
-		return nil
-	}
-	return e.value
-}
-
-func (e *expirableValue) Expired(q time.Time) bool {
-	if e == nil {
-		return true
-	}
-
-	return e.entryTime.Before(q)
-}
-
-var newExpirableValue = func(v interface{}) *expirableValue {
-	return newExpirableValueWithOffset(v, 0)
-}
-
-func newExpirableValueWithOffset(v interface{}, expiry int) *expirableValue {
-	return &expirableValue{
-		value:     v,
-		entryTime: time.Now().Add(time.Duration(expiry)),
-	}
-}
-
 func parDir(p string) string {
 	return filepath.Dir(p)
 }
@@ -65,7 +34,7 @@ func TestInit(t *testing.T) {
 
 	manifest := strings.Split(manifestStr, "\n")
 
-	expiryMs := 25
+	expiryMs := uint(25)
 
 	tick := time.Tick(time.Duration(expiryMs))
 
@@ -76,7 +45,7 @@ func TestInit(t *testing.T) {
 	for _, item := range manifest {
 		go func(p string) {
 			par := parDir(p)
-			exp := newExpirableValueWithOffset(p, expiryMs)
+			exp := NewExpirableValueWithOffset(p, expiryMs)
 
 			store.Put(par, exp)
 			retr, ok := store.Get(par)

--- a/exports.go
+++ b/exports.go
@@ -1,0 +1,34 @@
+package expirable
+
+import "time"
+
+type ExpirableValue struct {
+	value     interface{}
+	entryTime time.Time
+}
+
+func (e *ExpirableValue) Value() interface{} {
+	if e == nil {
+		return nil
+	}
+	return e.value
+}
+
+func (e *ExpirableValue) Expired(q time.Time) bool {
+	if e == nil {
+		return true
+	}
+
+	return e.entryTime.Before(q)
+}
+
+func NewExpirableValue(v interface{}) *ExpirableValue {
+	return NewExpirableValueWithOffset(v, 0)
+}
+
+func NewExpirableValueWithOffset(v interface{}, expiry uint) *ExpirableValue {
+	return &ExpirableValue{
+		value:     v,
+		entryTime: time.Now().Add(time.Duration(expiry)),
+	}
+}


### PR DESCRIPTION
This PR allows for a default exportable ExpirableValue that can be reused in packages without them having to re-define one.
